### PR TITLE
Use image.loadOriginalMetadata()

### DIFF
--- a/fixing_scripts/Restore_colors.py
+++ b/fixing_scripts/Restore_colors.py
@@ -85,9 +85,10 @@ def restore_image(conn, img, params) :
             tmp_ar = keyValue[0].split(' ')
             cNames[int(tmp_ar[1])] = keyValue[1]
           # LSM colors
-          if keyValue[0].startswith("DataChannel") and keyValue[0].endswith("Color"):
+          # In OMERO 5. we have DataChannel Color #2', 16711680
+          if keyValue[0].startswith("DataChannel") and "Color" in keyValue[0]:
             tmp_ar = keyValue[0].split(' ')
-            cCodes[int(tmp_ar[1].strip('#'))-1] = int(keyValue[1])
+            cCodes[int(tmp_ar[-1].strip('#'))-1] = int(keyValue[1])
 
       if cNames:
         for index, c in enumerate(img.getChannels()):


### PR DESCRIPTION
The Blitz Gateawy image.loadOriginalMetadata() method had a bug when this script was being developed, so a local copy of the method was used (with the fix). However, this issue has been fixed a long time now, AND the implementation of that method is changed in OMERO 5.x since the data is no longer retrieved from a file.

So, for this script to work on OMERO 5 (and 4.4) we should use image.loadOriginalMetadata().

Another issue I noticed, running this against an LSM file in 'develop' (OMERO 5.) is that the key-value pair for colour data is `"DataChannel Color #2": 16711680` which was not recognised by the script. I made some changes to work with this data. It should still work with OMERO 4.4 data, but haven't checked.
