### PR TITLE
Restore_colors params fixed in Insight

### DIFF
--- a/fixing_scripts/Restore_colors.py
+++ b/fixing_scripts/Restore_colors.py
@@ -210,7 +210,7 @@ def runAsScript():
     you can choose the channel colors manually.
     """, 
     
-    scripts.String(PARAM_DATATYPE, optional=False, grouping="1.1",
+    scripts.String(PARAM_DATATYPE, optional=False, grouping="1",
         description="The data you want to work with.", values=dataTypes, 
         default="Image"),
 


### PR DESCRIPTION
Tiny fix to parameters in Restore_colors as requested here: https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=7431&start=10#p13738

Screen-shots show the script UI in Insight before and after this fix:

![screen shot 2014-03-24 at 12 03 09](https://f.cloud.github.com/assets/900055/2498972/916c7f14-b34e-11e3-8af7-23cb3fffe187.png)

![screen shot 2014-03-24 at 12 06 53](https://f.cloud.github.com/assets/900055/2498973/95b859ee-b34e-11e3-853a-6915f7d26c0d.png)

Seems Insight is a bit sensitive to parameter grouping - something to watch out for!
